### PR TITLE
Fixing SMTP error when SSL is unavailable.

### DIFF
--- a/includes/functions/general.php
+++ b/includes/functions/general.php
@@ -491,11 +491,16 @@ function buckys_sendmail($to, $toName, $subject, $body){
 
     $mail = new PHPMailer();
 
-    $mail->SMTPSecure = 'TLS';
+	
+	//tls or ssl
+	if(SITE_USING_SSL)
+		$mail->SMTPSecure = 'ssl';
+	else
+		$mail->SMTPSecure = 'tls';
 
     $mail->IsSMTP();
     $mail->SMTPAuth = true;
-    $mail->SMTPSecure = 'ssl';
+    
     $mail->Port = SMTP_PORT;
     $mail->Host = SMTP_HOST;
     $mail->Username = SMTP_USERNAME;


### PR DESCRIPTION
When SSL is not available, SMTP email sending will fail because it by default attempts to use SSL. By first checking to see if SSL is enabled for the site, this error can be avoided by having SMTP use TLS instead.
